### PR TITLE
Fixed typo in URL configuration

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = 'http://nicholas-lacourse93.hithub.io/'
+baseURL = 'https://nicholas-lacourse93.github.io/'
 languageCode = 'en-us'
 title = 'Nicholas Lacourse'
 theme='barks'


### PR DESCRIPTION
Corrected typo in the URL key that was not probably loading the Hugo site onto GitHub pages. 