### PR TITLE
Changed url path to CV, was searching given path within current dir

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,7 +8,7 @@ Copyright = "Copyright &copy; 2022 Nicholas Lacourse. CC0 License."
 [[menu.main]]
     name = "CV"
     weight = 50
-    url = "files/lacourse-nicholas-cv.pdf"
+    url = "https://nicholas-lacourse93.github.io/files/lacourse-nicholas-cv.pdf"
 
 [params.head]
     author = "Nicholas Lacourse"


### PR DESCRIPTION
Changed CV static file path to a full URL path because it was searching sub-path within whatever directory you were currently in which was throwing back a 404 error due to that directory not existing. 